### PR TITLE
feat: added GetHistory method and optimized balance retrieval

### DIFF
--- a/Buff163.js
+++ b/Buff163.js
@@ -1,15 +1,12 @@
 const fs = require('fs');
 const axios = require('axios');
-
-const puppeteer = require('puppeteer');
-
 const buff_cookies = fs.readFileSync(
-    'cookies.txt', 
+    'cookies.txt',
     'utf8'
 );;
 
-const Buff163 = axios.create({ 
-    baseURL: 'https://buff.163.com/api' 
+const Buff163 = axios.create({
+    baseURL: 'https://buff.163.com/api'
 });
 
 let CSRFToken;
@@ -25,11 +22,11 @@ Buff163.interceptors.request.use(
 
             config.headers['X-CSRFToken'] = CSRFToken;
         }
-        
+
         config.headers['Cookie'] = cookies_being_sent.replace(/\r?\n|\r/g, '');
         config.headers['X-Requested-With'] = "XMLHttpRequest";
         config.headers['User-Agent'] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36";
-        
+
         return config;
     },
     error => Promise.reject(error)
@@ -38,11 +35,11 @@ Buff163.interceptors.request.use(
 Buff163.interceptors.response.use((response) =>
 {
     let new_cookies = response.headers['set-cookie'];
-        new_cookies = new_cookies.map((x) => ConvertCookieSTRToOBJ(x));
+    new_cookies = new_cookies.map((x) => ConvertCookieSTRToOBJ(x));
 
     let { csrf_token } = new_cookies.find((x) => x['csrf_token']);
 
-    CSRFToken = csrf_token;    
+    CSRFToken = csrf_token;
 
     return response;
 });
@@ -86,63 +83,121 @@ function GetBuffCookiesObj()
 module.exports.GetTradesToAccept = async function GetTradesToAccept()
 {
     let { data: { data } } = await Buff163.get("/market/steam_trade", { params: { _: Date.now() } });
-    
+
     let ids = data.map(({ tradeofferid }) => tradeofferid);
 
     return [...new Set(ids)];
 }
+module.exports.GetHistory = async function GetHistory(game = 'csgo') {
 
-module.exports.GetBalanceUSD = async function GetBalanceUSD()
-{
-    try
-    {
-        let { data: { Rates } } = await axios.get("https://api.dmarket.com/currency-rate/v1/rates");
-
-        console.log("[Buff163] CNY to USD Rate: " + Rates.CNY);
-
-        const browser = await puppeteer.launch({
-            headless: true,
-            args: ["--no-sandbox"]
-        });
-    
-        const page = await browser.newPage();
-    
-        await page.setViewport({ width: 1920, height: 1080 });
-        
-        page.goto("https://buff.163.com/market/buy_order/history?game=csgo");
-        page.setCookie(...GetBuffCookiesObj());
-    
-        await page.waitForNetworkIdle({ idleTime: 1000 });
-    
-        const element = await page.$("#navbar-cash-amount");
-        const text = await page.evaluate(el => el.textContent, element);
-
-        let cny = +text.replace("¥ ", "");
-
-        const tr_elements = await page.$$("tr");
-
-        for (let i = 0 ; i < tr_elements.length; i++)
-        {
-            const text = await page.evaluate(el => el.textContent, tr_elements[i]);
-
-            if (text.includes("Success") || text.includes("Buy failed-refunded"))
-                continue;
-
-            const words = text.split(" ");
-            const index = words.findIndex((x) => x === "¥");
-
-            if (index !== -1)
-            {
-                cny += +(words[index + 1].trim());
+    // Function for retrieving purchase history
+    const getBuyOrderHistory = async (data) => {
+        try {
+            if (data.page_num <= data.total_page) {
+                let response = await Buff163.get(`/market/buy_order/history?game=${game}&page_num=${data.page_num}&page_size=10`);
+                let next = response.data.data;
+                data.page_num = next.page_num + 1;
+                data.total_page = next.total_page;
+                data.items = [...(data.items || []), ...next.items];
+                data.goods_infos = { ...(data.goods_infos || []), ...next.goods_infos };
+                data.user_infos = { ...(data.user_infos || []), ...next.user_infos };
+                await new Promise(resolve => setTimeout(resolve, 500));
+                return getBuyOrderHistory(data);
+            } else {
+                return data;
             }
+        } catch (error) {
+            console.error(`[Buff163] Error fetching buy order history: ${error.message}`);
+            throw error;
+        }
+    };
+
+    // Function for obtaining exchange rate with caching
+    const getCachedExchangeRate = (() => {
+        const cache = {};
+
+        return async (date) => {
+            if (cache[date]) {
+                return cache[date];
+            }
+
+            const baseCurrency = 'USD';
+            const targetCurrency = 'CNY';
+            const url = `https://query1.finance.yahoo.com/v7/finance/download/${baseCurrency}${targetCurrency}=X?period1=${date}&period2=${date}&interval=1d&events=history`;
+            try {
+                console.log(`[Buff163] Fetching exchange rate for ${date}...`);
+                let response = await axios.get(url);
+                let rate = +response.data.split(',').slice(-2).shift();
+                cache[date] = rate;
+                return rate;
+            } catch (error) {
+                console.error(`[Buff163] Error fetching exchange rate: ${error.message}`);
+                throw error;
+            }
+        };
+    })();
+
+    try {
+        let data = await getBuyOrderHistory({ page_num: 1, total_page: 2 });
+        let items = data.items;
+
+        // Grouping by day
+        let groupDaily = items.filter(i => i.state != 'FAIL').reduce((acc, item) => {
+            const date = new Date((item.buyer_pay_time || item.transact_time) * 1000);
+            const year = date.getUTCFullYear();
+            const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+            const day = String(date.getUTCDate()).padStart(2, '0');
+            const dayText = `${year}/${month}/${day}`;
+            if (!acc[dayText]) {
+                acc[dayText] = [item];
+            } else {
+                acc[dayText].push(item);
+            }
+            return acc;
+        }, {});
+
+        // Group processing
+        for await (const [key, items_] of Object.entries(groupDaily)) {
+            let transactTime = items_[0].transact_time || items_[0].buyer_pay_time;
+            let rate = await getCachedExchangeRate(transactTime);
+            items_.forEach((item) => {
+                item.price_usd = +(item.price / rate);
+                item.rateCNY = rate;
+            });
+            await new Promise(resolve => setTimeout(resolve, 500));
         }
 
-        await browser.close();
-
-        return cny / Rates.CNY;
+        // Preparation of the final result
+        return items.map(item => {
+            return {
+                market_hash_name: data.goods_infos[item.asset_info.goods_id].market_hash_name,
+                price_usd: item.price_usd,
+                price: item.price,
+                state: item.state,
+                date: new Date((item.buyer_pay_time || item.transact_time) * 1000)
+            };
+        });
+    } catch (error) {
+        console.error(`[Buff163] Error in GetHistory: ${error.message}`);
+        throw error;
     }
-    catch 
-    {
+};
+module.exports.GetBalanceUSD = async function GetBalanceUSD(game = 'csgo') {
+    try {
+        let { data: { Rates } } = await axios.get("https://api.dmarket.com/currency-rate/v1/rates");
+        let cny = 0;
+        console.log("[Buff163] CNY to USD today rate: " + Rates.CNY);
+        let records = await module.exports.GetHistory(game);
+        for (let i = 0; i < records.length; i++) {
+            let item = records[i];
+            if (item.state == 'SUCCESS' || item.state == 'FAIL')
+                continue;
+            cny += +item.price;
+            item.price_usd_dm = +item.price / Rates.CNY;
+            console.log(`[Buff163] ${item.market_hash_name} - ${item.price} CNY, ${item.price_usd} USD(yahoo), ${item.price_usd_dm} USD (DMarket)`);
+        }
+        return cny / Rates.CNY;
+    }catch(e) {
         return 0;
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^1.3.4",
-    "puppeteer": "^19.7.4",
     "steam-totp": "^2.1.2",
     "steam-tradeoffer-manager": "^2.10.5",
     "steam-user": "^4.27.1",


### PR DESCRIPTION
- Added `GetHistory` method to fetch buy_order/history using API
  - Uses caching of currency rates with `getCachedExchangeRate`
  - Currency rates fetched from Yahoo to get historical rates based on the date of orders (grouped by day)
- Changed `GetBalanceUSD` method
  - Replaced Puppeteer with data from `GetHistory`, retaining the same functionality